### PR TITLE
Fix lane DataLossOverview component

### DIFF
--- a/flowcraft-webapp/frontend/src/components/ReportsSample.js
+++ b/flowcraft-webapp/frontend/src/components/ReportsSample.js
@@ -779,9 +779,13 @@ class DataLossOverview extends React.Component{
 
                 if (!laneData.hasOwnProperty(d.lane)){
                     const parentLane = this._findForkParent(d.pipelineId, d.lane);
-                    laneData[d.lane] = JSON.parse(JSON.stringify(laneData[parentLane]));
-                    laneData[d.lane].push(d);
-                    !tempKeys.includes(parentLane) && tempKeys.push(parentLane);
+                    // checks if laneData[parentLane] hasn't been removed by the
+                    // for loop below
+                    if (typeof laneData[parentLane] !== "undefined") {
+                        laneData[d.lane] = JSON.parse(JSON.stringify(laneData[parentLane]));
+                        laneData[d.lane].push(d);
+                        !tempKeys.includes(parentLane) && tempKeys.push(parentLane);
+                    }
                 } else {
                     laneData[d.lane].push(d)
                 }

--- a/flowcraft-webapp/frontend/src/components/ReportsSample.js
+++ b/flowcraft-webapp/frontend/src/components/ReportsSample.js
@@ -241,8 +241,6 @@ class Overview extends React.Component{
 
     render(){
 
-        console.log("render sample overview")
-
         const style = {
             header: {
                 fontSize: "20px",
@@ -777,8 +775,7 @@ class DataLossOverview extends React.Component{
                     // instances it will look for parentLanes that aren't in
                     // laneData object
                     if (laneData.hasOwnProperty(parentLane)) {
-                        console.log(laneData[parentLane])
-                        laneData[d.lane] = JSON.parse(JSON.stringify(laneData[parentLane]));
+                        laneData[d.lane] = laneData[parentLane];
                         laneData[d.lane].push(d);
                         !tempKeys.includes(parentLane) && tempKeys.push(parentLane);
                     }

--- a/flowcraft-webapp/frontend/src/components/ReportsSample.js
+++ b/flowcraft-webapp/frontend/src/components/ReportsSample.js
@@ -686,6 +686,16 @@ class GaugeChart extends React.Component{
 
 class DataLossOverview extends React.Component{
 
+    /**
+     * Function that generates the data to feed to the data loss graph
+     * @param {Object} reportData - the full reportData passed to the flowcraft
+     * report.json
+     * @param {String} sample - the name of the sample being currently asked for
+     * display
+     * @returns {Object} - the object for the graph generation with highcharts.
+     * In this case a sparlkline or a multisparkline plot, depending on the
+     * the pipeline being linear or forked.
+     */
     getChartData = (reportData, sample) => {
 
         let tempData = [];
@@ -775,19 +785,28 @@ class DataLossOverview extends React.Component{
                     // instances it will look for parentLanes that aren't in
                     // laneData object
                     if (laneData.hasOwnProperty(parentLane)) {
-                        laneData[d.lane] = laneData[parentLane];
+                        // create a deep copy of the laneData[parentLane] object
+                        // into the entry being added by d.lane.
+                        laneData[d.lane] = JSON.parse(JSON.stringify(laneData[parentLane]));
+                        // then since laneData[parentLane] should be an array
+                        // we can directly use push here.
                         laneData[d.lane].push(d);
                         !tempKeys.includes(parentLane) && tempKeys.push(parentLane);
                     }
                 } else {
+                    // if d.lane is already in laneData then use push to
+                    // continue adding new d entries.
                     laneData[d.lane].push(d)
                 }
             }
 
+            // removes unwanted entries from laneData
             for (const k of tempKeys){
                 delete laneData[k];
             }
 
+            // iterates through laneData in order to create the object that will
+            // create the graph for data loss
             for (const d of Object.keys(laneData)){
                 const data = laneData[d].map((v) => {return parseFloat(v.value) / maxBp})
                 const categories = laneData[d].map((v) => {return v.process});

--- a/flowcraft-webapp/frontend/src/components/reports/utils.js
+++ b/flowcraft-webapp/frontend/src/components/reports/utils.js
@@ -320,8 +320,15 @@ export const sortColor = (a, b) => {
     return aValue - bValue
 };
 
+/**
+ * Function to fetch all the lanes that are parent from the provided laneNumber
+ * @param {String} laneNumber - the number of the lane that should be queried
+ * @param {Object} dict - the dictionary with the forks of the currently
+ * selected pipeline.
+ * @returns {number[]} - the parent lanes
+ */
 export const getParentLanes = (laneNumber, dict) => {
-    let parentLanes = [parseInt(laneNumber)];
+    let parentLanes = [];
 
     while (true) {
         let found = Object.entries(dict).filter( (v) => {


### PR DESCRIPTION
Some instances of the `DataLossOverview` component would break the app because sometimes `laneData[parentLane]` would get `undefined`. This happens when the `parentLane` hasn't been previously added to `laneData` object. The fix suggested here is to add another if statement to the part of the code that attempts to add this object to the `laneData`, preventing the attempt to add an entry that would otherwise render `undefined` when attempting to fetch `laneData[parentLane]`.

My example: 

I have a `laneData` object as such:
```js
{"5":[
{"value":384309323,"processId":"8","process":"integrity_coverage","lane":"5","pipelineId":"wise_torricelli"}
]}
```

and in the next iteration of the loop it gets a `parentLane` of `1` and a `d.lane` of `3`. In this case it would add the `d.lane` to `laneData` but not the `parentLane` in the following line:

```js
laneData[d.lane] = JSON.parse(JSON.stringify(laneData[parentLane]));
laneData[d.lane].push(d);
```

This will render `laneData[parentLane]` `undefined`and when attempting to push to the array it would raise an error and stop the rendering of the entire component.

In attachment I leave a `pipeline_report.json` so it can be test:
[pipeline_report.zip](https://github.com/assemblerflow/flowcraft-webapp/files/2465628/pipeline_report.zip)

