### PR TITLE
Alter metadata handling for the typing information in phylocanvas

### DIFF
--- a/flowcraft-webapp/frontend/src/components/reports/phylogeny.js
+++ b/flowcraft-webapp/frontend/src/components/reports/phylogeny.js
@@ -40,16 +40,24 @@ export class Phylogeny extends React.Component{
 
         const metadata = new Map();
 
-        for (const m of rawMetadata){
-            const currentMeta = m.reportJson.metadata[0];
-            const sample = currentMeta.sample;
+        for (const m of rawMetadata) {
+            for (const x of m.reportJson.metadata) {
 
-            if (!metadata.has(sample)){
-                metadata.set(sample, {});
+                const currentMeta = x;
+                console.log("currentMeta:", currentMeta)
+
+                const sample = currentMeta.sample;
+
+                if (!metadata.has(sample)) {
+                    metadata.set(sample, {});
+
+
+                }
+
+                metadata.get(sample)[currentMeta.column] = {label: currentMeta.treeData};
             }
-
-            metadata.get(sample)[currentMeta.column] = {label: currentMeta.treeData};
         }
+
 
         return metadata
 
@@ -174,6 +182,7 @@ class PhylogeneticTree extends React.Component {
     componentDidMount = () => {
 
         const colors = randomColor({count: this.props.metadata.size});
+        console.log(this.node);
         this.tree = Phylocanvas.createTree(this.node, {});
 
         let _ids = [];

--- a/flowcraft-webapp/frontend/src/components/reports/phylogeny.js
+++ b/flowcraft-webapp/frontend/src/components/reports/phylogeny.js
@@ -40,17 +40,13 @@ export class Phylogeny extends React.Component{
 
         const metadata = new Map();
 
-        for (const m of rawMetadata) {
-            for (const x of m.reportJson.metadata) {
-
-                const currentMeta = x;
-                console.log("currentMeta:", currentMeta)
+        for (const sampleMetadata of rawMetadata) {
+            for (const currentMeta of sampleMetadata.reportJson.metadata) {
 
                 const sample = currentMeta.sample;
 
                 if (!metadata.has(sample)) {
                     metadata.set(sample, {});
-
 
                 }
 

--- a/flowcraft-webapp/frontend/src/components/reports/phylogeny.js
+++ b/flowcraft-webapp/frontend/src/components/reports/phylogeny.js
@@ -182,7 +182,6 @@ class PhylogeneticTree extends React.Component {
     componentDidMount = () => {
 
         const colors = randomColor({count: this.props.metadata.size});
-        console.log(this.node);
         this.tree = Phylocanvas.createTree(this.node, {});
 
         let _ids = [];


### PR DESCRIPTION
This change allows for the metadata field to have multiple entries. This is necessary for the den-im recipe where the dengue_typing process retrieves the typing information of not only the sample, but also the closest reference (although this behavior is optional). 